### PR TITLE
Fix casting double -> biginteger

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@
     * New `sigfig` and `digits` arguments control the displayed precision.
     * New `notation` argument chooses decimal, scientific or hexadecimal output.
     * New options `"bignum.sigfig"` and `"bignum.max_dec_width"` determine the default formatting.
-* Fixed identification of lossy casts when converting between `biginteger()` and `bigfloat()` vectors.
+* Fixed how `biginteger()` vectors are created from large `double()` vectors (e.g. `biginteger(1e10)`). This would previously return `NA`.
+* Fixed identification of lossy casts when converting between `biginteger()` and `bigfloat()` vectors. This would previously return `NA` silently, but now it raises a warning.
+
 
 # bignum 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # bignum (development version)
 
-* `format()` functions now support customized output.
+* `format()` functions now support customized output (#15).
     * New `sigfig` and `digits` arguments control the displayed precision.
     * New `notation` argument chooses decimal, scientific or hexadecimal output.
     * New options `"bignum.sigfig"` and `"bignum.max_dec_width"` determine the default formatting.
-* Fixed how `biginteger()` vectors are created from large `double()` vectors (e.g. `biginteger(1e10)`). This would previously return `NA`.
+* Fixed how `biginteger()` vectors are created from large `double()` vectors (e.g. `biginteger(1e10)`). This would previously return `NA` (#16).
 * Fixed identification of lossy casts when converting between `biginteger()` and `bigfloat()` vectors. This would previously return `NA` silently, but now it raises a warning.
 
 

--- a/R/biginteger.R
+++ b/R/biginteger.R
@@ -132,7 +132,7 @@ vec_cast.integer.bignum_biginteger <- function(x, to, ..., x_arg = "", to_arg = 
 
 #' @export
 vec_cast.bignum_biginteger.double <- function(x, to, ..., x_arg = "", to_arg = "") {
-  out <- new_biginteger(as.character(x))
+  out <- new_biginteger(format(x, trim = TRUE, scientific = FALSE))
   lossy <- floor(x) != x & !is.na(x)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -132,3 +132,7 @@ test_that("missing value works", {
   expect_equal(as_biginteger(NA_character_), NA_biginteger_)
   expect_equal(as.character(NA_biginteger_), NA_character_)
 })
+
+test_that("difficult cases work", {
+  expect_equal(biginteger(c(1, 1e10)), biginteger(c("1", "10000000000")))
+})


### PR DESCRIPTION
Old:
```r
> biginteger(c(1, 1e10))
<biginteger[2]>
[1] 1    <NA>
```

New:
```r
> biginteger(c(1, 1e10))
<biginteger[2]>
[1] 1           10000000000
```