### PR TITLE
Fix additional cast issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,13 @@
     * New `notation` argument chooses decimal, scientific or hexadecimal output.
     * New options `"bignum.sigfig"` and `"bignum.max_dec_width"` determine the default formatting.
     * When a bignum vector is stored in a [tibble](https://tibble.tidyverse.org) column, the default formatting instead consults `"pillar.sigfig"` and `"pillar.max_dec_width"`. See `vignette("digits", package = "pillar")`.
-* Fixed how `biginteger()` vectors are created from large `double()` vectors (e.g. `biginteger(1e10)`). This would previously return `NA`.
-* Fixed identification of lossy casts when converting between `biginteger()` and `bigfloat()` vectors. This would previously return `NA` silently, but now it raises a warning.
+    
+## Bug Fixes
+
+* Casting a non-integer `double()` to `biginteger()` now returns the truncated integer, consistent with base vectors. Previously it would return `NA`. A lossy cast warning is still raised.
+* Casting a large `double()` to `biginteger()` now works correctly. Previously it might return `NA`, depending on the value of `options("scipen")`.
+* Casting `Inf` to `biginteger()` now raises a lossy cast warning.
+* Casting a large `biginteger()` to `bigfloat()` now raises a lossy cast warning when the `bigfloat()` precision is exceeded.
 
 
 # bignum 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Casting a large `double()` to `biginteger()` now works correctly. Previously it might return `NA`, depending on the value of `options("scipen")`.
 * Casting `Inf` to `biginteger()` now raises a lossy cast warning.
 * Casting a large `biginteger()` to `bigfloat()` now raises a lossy cast warning when the `bigfloat()` precision is exceeded.
+* `is.finite()` and `is.infinite()` now correctly handle large `bigfloat()` values. Previously, such large values were considered to be infinite.
 
 
 # bignum 0.1.0

--- a/R/bigfloat.R
+++ b/R/bigfloat.R
@@ -150,14 +150,6 @@ vec_cast.bignum_bigfloat.bignum_biginteger <- function(x, to, ..., x_arg = "", t
 }
 
 #' @export
-vec_cast.bignum_biginteger.bignum_bigfloat <- function(x, to, ..., x_arg = "", to_arg = "") {
-  rounded <- c_bigfloat_floor(x)
-  out <- new_biginteger(vec_data(rounded))
-  lossy <- rounded != x & !is.na(x)
-  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
-}
-
-#' @export
 vec_cast.bignum_bigfloat.character <- function(x, to, ..., x_arg = "", to_arg = "") {
   stop_incompatible_cast(x, to, x_arg = x_arg, to_arg = to_arg)
 }

--- a/R/biginteger.R
+++ b/R/biginteger.R
@@ -132,10 +132,10 @@ vec_cast.integer.bignum_biginteger <- function(x, to, ..., x_arg = "", to_arg = 
 
 #' @export
 vec_cast.bignum_biginteger.double <- function(x, to, ..., x_arg = "", to_arg = "") {
-  x <- vec_cast(x, new_bigfloat())
-  x_int <- trunc(x)
-  out <- new_biginteger(format(x_int, notation = "dec"))
-  lossy <- (x_int != x & !is.na(x)) | is.infinite(x)
+  x_big <- vec_cast(x, new_bigfloat())
+  rounded <- trunc(x_big)
+  out <- new_biginteger(vec_data(rounded))
+  lossy <- (rounded != x_big & !is.na(x)) | is.infinite(x)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 
@@ -143,6 +143,14 @@ vec_cast.bignum_biginteger.double <- function(x, to, ..., x_arg = "", to_arg = "
 vec_cast.double.bignum_biginteger <- function(x, to, ..., x_arg = "", to_arg = "") {
   out <- c_biginteger_to_double(x)
   lossy <- abs(x) >= biginteger(2)^53L & !is.na(x)
+  maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
+}
+
+#' @export
+vec_cast.bignum_biginteger.bignum_bigfloat <- function(x, to, ..., x_arg = "", to_arg = "") {
+  rounded <- trunc(x)
+  out <- new_biginteger(vec_data(rounded))
+  lossy <- (rounded != x & !is.na(x)) | is.infinite(x)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 

--- a/R/biginteger.R
+++ b/R/biginteger.R
@@ -132,8 +132,10 @@ vec_cast.integer.bignum_biginteger <- function(x, to, ..., x_arg = "", to_arg = 
 
 #' @export
 vec_cast.bignum_biginteger.double <- function(x, to, ..., x_arg = "", to_arg = "") {
-  out <- new_biginteger(format(x, trim = TRUE, scientific = FALSE))
-  lossy <- floor(x) != x & !is.na(x)
+  x <- vec_cast(x, new_bigfloat())
+  x_int <- trunc(x)
+  out <- new_biginteger(format(x_int, notation = "dec"))
+  lossy <- (x_int != x & !is.na(x)) | is.infinite(x)
   maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg)
 }
 

--- a/R/format.R
+++ b/R/format.R
@@ -62,7 +62,7 @@ format.bignum_biginteger <- function(x, ..., sigfig = NULL, digits = NULL,
   switch(notation,
     fit = format_fit(x, sigfig = sigfig, digits = digits),
     sci = format(
-      vec_cast(x, new_bigfloat()),
+      warn_on_lossy_cast(vec_cast(x, new_bigfloat())),
       ...,
       sigfig = sigfig,
       digits = digits,

--- a/R/vctrs-math.R
+++ b/R/vctrs-math.R
@@ -42,9 +42,9 @@ vec_math_bigfloat <- function(.fn, .x, ..., na.rm = FALSE) {
 
     # Other
     mean = c_bigfloat_sum(.x, na.rm) / sum(!is.na(.x)),
-    is.nan = is.nan(allow_lossy_cast(vec_cast(.x, double()))),
-    is.infinite = is.infinite(allow_lossy_cast(vec_cast(.x, double()))),
-    is.finite = is.finite(allow_lossy_cast(vec_cast(.x, double()))),
+    is.nan = vec_data(.x) %|% "NA" == "NaN",
+    is.infinite = vec_data(.x) %in% c("Inf", "-Inf"),
+    is.finite = !(vec_data(.x) %in% c(NA, "NaN", "Inf", "-Inf")),
 
     # else
     stop_unsupported(.x, .fn)
@@ -77,9 +77,9 @@ vec_math.bignum_biginteger <- function(.fn, .x, ..., na.rm = FALSE) {
 
     # Other
     mean = c_biginteger_sum(.x, na.rm) / sum(!is.na(.x)),
-    is.nan = rep_len(FALSE, length(.x)),
+    is.nan = rep_along(.x, FALSE),
     is.finite = !is.na(.x),
-    is.infinite = rep_len(FALSE, length(.x)),
+    is.infinite = rep_along(.x, FALSE),
 
     # else
     vec_math_bigfloat(.fn, .x, ..., na.rm = na.rm)

--- a/tests/testthat/test-bigfloat.R
+++ b/tests/testthat/test-bigfloat.R
@@ -107,12 +107,6 @@ test_that("lossy casts are caught", {
   expect_error(vec_cast(lossy_val, double()), class = "vctrs_error_cast_lossy")
   expect_warning(as.double(lossy_val), class = "bignum_warning_cast_lossy")
 
-  # bigfloat -> biginteger
-  lossy_val <- bigfloat(1.5)
-  expect_equal(as_biginteger(lossy_val - 0.5), biginteger(1))
-  expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
-  expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
-
   # biginteger -> bigfloat
   lossy_val <- biginteger(10)^51L + 1L
   expect_equal(as_bigfloat(lossy_val - 1L), bigfloat(1e51))

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -103,6 +103,16 @@ test_that("lossy casts are caught", {
   lossy_val <- Inf
   expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
   expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
+
+  # bigfloat -> biginteger
+  lossy_val <- bigfloat(1.5)
+  expect_equal(as_biginteger(lossy_val - 0.5), biginteger(1))
+  expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
+  expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
+
+  lossy_val <- bigfloat(Inf)
+  expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
+  expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
 })
 
 test_that("combination works", {

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -99,6 +99,10 @@ test_that("lossy casts are caught", {
   lossy_val <- 1.5
   expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
   expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
+
+  lossy_val <- Inf
+  expect_error(vec_cast(lossy_val, new_biginteger()), class = "vctrs_error_cast_lossy")
+  expect_warning(as_biginteger(lossy_val), class = "bignum_warning_cast_lossy")
 })
 
 test_that("combination works", {
@@ -135,4 +139,9 @@ test_that("missing value works", {
 
 test_that("difficult cases work", {
   expect_equal(biginteger(c(1, 1e10)), biginteger(c("1", "10000000000")))
+  expect_equal(biginteger(c(1, 1e23)), biginteger(c("1", "100000000000000000000000")))
+  expect_equal(
+    expect_warning(biginteger(c(1, 1e-10)), class = "bignum_warning_cast_lossy"),
+    biginteger(c("1", "0"))
+  )
 })

--- a/tests/testthat/test-vctrs-math.R
+++ b/tests/testthat/test-vctrs-math.R
@@ -65,6 +65,10 @@ test_that("special value math works", {
   expect_equal(is.finite(bigfloat(x)), is.finite(x))
   expect_equal(is.infinite(suppressWarnings(biginteger(x))), is.infinite(suppressWarnings(as.integer(x))))
   expect_equal(is.infinite(bigfloat(x)), is.infinite(x))
+
+  x <- bigfloat("1e1000")
+  expect_true(is.finite(x))
+  expect_false(is.infinite(x))
 })
 
 test_that("math returning same type works", {

--- a/tests/testthat/test-vctrs-math.R
+++ b/tests/testthat/test-vctrs-math.R
@@ -59,11 +59,11 @@ test_that("trunc() works", {
 
 test_that("special value math works", {
   x <- c(1, NA, NaN, Inf, -Inf)
-  expect_equal(is.nan(biginteger(x)), is.nan(suppressWarnings(as.integer(x))))
+  expect_equal(is.nan(suppressWarnings(biginteger(x))), is.nan(suppressWarnings(as.integer(x))))
   expect_equal(is.nan(bigfloat(x)), is.nan(x))
-  expect_equal(is.finite(biginteger(x)), is.finite(suppressWarnings(as.integer(x))))
+  expect_equal(is.finite(suppressWarnings(biginteger(x))), is.finite(suppressWarnings(as.integer(x))))
   expect_equal(is.finite(bigfloat(x)), is.finite(x))
-  expect_equal(is.infinite(biginteger(x)), is.infinite(suppressWarnings(as.integer(x))))
+  expect_equal(is.infinite(suppressWarnings(biginteger(x))), is.infinite(suppressWarnings(as.integer(x))))
   expect_equal(is.infinite(bigfloat(x)), is.infinite(x))
 })
 


### PR DESCRIPTION
* Casting a non-integer `double()` to `biginteger()` now returns the truncated integer, consistent with base vectors. Previously it would return `NA`. A lossy cast warning is still raised.
* Casting `Inf` to `biginteger()` now raises a lossy cast warning.
* `is.finite()` and `is.infinite()` now correctly handle large `bigfloat()` values. Previously, such large values were considered to be infinite.