### PR TITLE
Pretty printing within tibble

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,17 @@
 # bignum (development version)
 
+## New features
+
 * `format()` functions now support customized output.
     * New `sigfig` and `digits` arguments control the displayed precision.
     * New `notation` argument chooses decimal, scientific or hexadecimal output.
     * New options `"bignum.sigfig"` and `"bignum.max_dec_width"` determine the default formatting.
-    * When a bignum vector is stored in a [tibble](https://tibble.tidyverse.org) column, the default formatting instead consults `"pillar.sigfig"` and `"pillar.max_dec_width"`. See `vignette("digits", package = "pillar")`.
+* When a bignum vector is stored in a [tibble](https://tibble.tidyverse.org) column, the formatting is adjusted to aid reading data vertically.
+    * The decimal point and exponent are aligned across rows and negative numbers are colored red.
+    * The options `"pillar.sigfig"` and `"pillar.max_dec_width"` determine tibble formatting.
+    * See `vignette("digits", package = "pillar")` for details.
     
-## Bug Fixes
+## Bug fixes
 
 * Casting a non-integer `double()` to `biginteger()` now returns the truncated integer, consistent with base vectors. Previously it would return `NA`. A lossy cast warning is still raised.
 * Casting a large `double()` to `biginteger()` now works correctly. Previously it might return `NA`, depending on the value of `options("scipen")`.

--- a/R/pillar.R
+++ b/R/pillar.R
@@ -28,13 +28,13 @@ split_decimal <- function(x, sigfig, notation) {
   rhs[dec] <- vapply(lhs_rhs[dec], getElement, "", 2)
 
   out <- list(
-    num = num,  # lgl
-    neg = neg,  # lgl
-    other = other,  # chr
-    lhs = lhs,  # chr
-    dec = dec,  # lgl
-    rhs = rhs,  # chr
-    exp = exp   # int
+    num = num, # lgl
+    neg = neg, # lgl
+    other = other, # chr
+    lhs = lhs, # chr
+    dec = dec, # lgl
+    rhs = rhs, # chr
+    exp = exp # int
   )
 
   attr(out, "width") <- get_decimal_width(out)
@@ -95,7 +95,7 @@ style_mantissa <- function(x) {
 style_exponent <- function(x) {
   num <- !is.na(x)
   if (!any(num)) {
-    return (rep_along(x, ""))
+    return(rep_along(x, ""))
   }
 
   neg <- num & x < 0

--- a/R/pillar.R
+++ b/R/pillar.R
@@ -1,3 +1,56 @@
+split_decimal <- function(x, sigfig, notation) {
+  fmt <- format(x, sigfig = sigfig, notation = notation)
+
+  num <- is.finite(x)
+  neg <- !is.na(x) & x < 0
+  other <- ifelse(!num, fmt, rep_along(x, NA_character_))
+
+  # split number into mantissa + exponent
+  mnt <- rep_along(x, NA_character_)
+  exp <- rep_along(x, NA_integer_)
+  if (notation == "sci") {
+    mnt_exp <- strsplit(fmt, "e", fixed = TRUE)
+    mnt[num] <- vapply(mnt_exp[num], getElement, "", 1)
+    exp[num] <- as.integer(vapply(mnt_exp[num], getElement, "", 2))
+
+    # don't show exponent for exact zero
+    exp[x == 0] <- NA_integer_
+  } else {
+    mnt <- ifelse(num, fmt, mnt)
+  }
+
+  # split mantissa into lhs + dec + rhs
+  dec <- grepl(".", mnt, fixed = TRUE)
+  lhs <- rep_along(x, "")
+  rhs <- rep_along(x, "")
+  lhs_rhs <- strsplit(mnt, ".", fixed = TRUE)
+  lhs[num] <- vapply(lhs_rhs[num], getElement, "", 1)
+  rhs[dec] <- vapply(lhs_rhs[dec], getElement, "", 2)
+
+  out <- list(
+    num = num,  # lgl
+    neg = neg,  # lgl
+    other = other,  # chr
+    lhs = lhs,  # chr
+    dec = dec,  # lgl
+    rhs = rhs,  # chr
+    exp = exp   # int
+  )
+
+  attr(out, "width") <- get_decimal_width(out)
+  out
+}
+
+get_decimal_width <- function(x) {
+  exp <- x$exp[!is.na(x$exp)]
+  exp_width <- any(exp < 0) + max(2 + trunc(log10(abs(exp) + 0.5)), 0)
+
+  mnt_width <- max(nchar(x$lhs)) + any(x$dec) + max(nchar(x$rhs))
+  other_width <- nchar(x$other[!x$num], type = "width")
+
+  max(mnt_width + exp_width, other_width)
+}
+
 # Dynamically exported, see zzz.R
 pillar_shaft.bignum_vctr <- function(x, ...) {
   sigfig <- getOption("pillar.sigfig", 3L)
@@ -10,11 +63,11 @@ pillar_shaft.bignum_vctr <- function(x, ...) {
     abort("Option pillar.max_dec_width must be an integer.")
   }
 
-  dec <- format(x, notation = "dec", sigfig = sigfig)
-  sci <- format(x, notation = "sci", sigfig = sigfig)
+  dec <- split_decimal(x, sigfig = sigfig, notation = "dec")
+  sci <- split_decimal(x, sigfig = sigfig, notation = "sci")
 
-  dec_width <- pillar::get_max_extent(dec)
-  sci_width <- pillar::get_max_extent(sci)
+  dec_width <- attr(dec, "width")
+  sci_width <- attr(sci, "width")
 
   if (dec_width > max_dec_width) {
     dec <- NULL
@@ -29,10 +82,47 @@ pillar_shaft.bignum_vctr <- function(x, ...) {
   )
 }
 
-style_bignum <- function(x) {
-  x[is.na(x)] <- pillar::style_na("NA")
+style_mantissa <- function(x) {
+  out <- paste0(
+    pillar::align(x$lhs, align = "right"),
+    ifelse(x$dec, ".", ifelse(any(x$dec), " ", "")),
+    pillar::align(x$rhs, align = "left")
+  )
+  pillar::style_num(out, x$neg)
+}
 
-  x
+# copied from pillar:::supernum()
+style_exponent <- function(x) {
+  num <- !is.na(x)
+  if (!any(num)) {
+    return (rep_along(x, ""))
+  }
+
+  neg <- num & x < 0
+  if (any(neg)) {
+    sign_chr <- ifelse(neg, "-", "+")
+    sign_chr[!num] <- " "
+  } else {
+    sign_chr <- rep_along(x, "")
+  }
+
+  digits <- as.character(abs(x))
+  digits[!num] <- ""
+
+  exp <- paste0(sign_chr, format(digits, justify = "right"))
+
+  paste0(
+    pillar::style_subtle(ifelse(num, "e", " ")),
+    pillar::style_num(exp, neg)
+  )
+}
+
+style_bignum <- function(x) {
+  pillar::align(ifelse(
+    x$num,
+    paste0(style_mantissa(x), style_exponent(x$exp)),
+    pillar::style_na(x$other)
+  ), align = "right")
 }
 
 #' @export
@@ -42,7 +132,7 @@ format.pillar_shaft_bignum <- function(x, width, ...) {
     abort(paste0("Need at least width ", min_width, ", requested ", width, "."))
   }
 
-  fmt <- if (is.null(x$dec) || width < attr(x, "width")) {
+  fmt <- if (is.null(x$dec) || width < attr(x$dec, "width")) {
     x$sci
   } else {
     x$dec
@@ -52,7 +142,7 @@ format.pillar_shaft_bignum <- function(x, width, ...) {
 
   # pad because pillar expects 'width'
   used_width <- pillar::get_extent(row)
-  row <- paste0(strrep(" ", width - used_width), row)
+  row <- paste0(strrep(" ", max(width - used_width, 0)), row)
 
   pillar::new_ornament(row, align = "right")
 }

--- a/tests/testthat/_snaps/pillar.md
+++ b/tests/testthat/_snaps/pillar.md
@@ -48,19 +48,19 @@
       print(pillar::pillar_shaft(x), width = 8)
     Output
       <pillar_ornament>
-         2e+00
-      2.05e+03
-      2.10e+06
-      2.15e+09
+        2   e0
+        2.05e3
+        2.10e6
+        2.15e9
             NA
     Code
       print(pillar::pillar_shaft(x), width = 9)
     Output
       <pillar_ornament>
-          2e+00
-       2.05e+03
-       2.10e+06
-       2.15e+09
+         2   e0
+         2.05e3
+         2.10e6
+         2.15e9
              NA
 
 ---
@@ -70,18 +70,18 @@
       with_options(pillar.sigfig = 4, print(pillar::pillar_shaft(x), width = 9))
     Output
       <pillar_ornament>
-          2e+00
-      2.048e+03
-      2.097e+06
-      2.147e+09
+        2    e0
+        2.048e3
+        2.097e6
+        2.147e9
              NA
     Code
       with_options(pillar.max_dec_width = 8, pillar::pillar_shaft(x))
     Output
       <pillar_ornament>
-         2e+00
-      2.05e+03
-      2.10e+06
-      2.15e+09
-            NA
+      2   e0
+      2.05e3
+      2.10e6
+      2.15e9
+          NA
 

--- a/tests/testthat/_snaps/pillar.md
+++ b/tests/testthat/_snaps/pillar.md
@@ -32,7 +32,7 @@
     Error <rlang_error>
       Option pillar.max_dec_width must be an integer.
 
-# biginteger formats correctly
+# width calculations work
 
     Code
       x <- c(biginteger(2^seq(1, 40, 10)), NA)
@@ -52,7 +52,7 @@
         2.05e3
         2.10e6
         2.15e9
-            NA
+       NA     
     Code
       print(pillar::pillar_shaft(x), width = 9)
     Output
@@ -61,20 +61,7 @@
          2.05e3
          2.10e6
          2.15e9
-             NA
-
----
-
-    Code
-      x <- c(biginteger(2^seq(1, 40, 10)), NA)
-      with_options(pillar.sigfig = 4, print(pillar::pillar_shaft(x), width = 9))
-    Output
-      <pillar_ornament>
-        2    e0
-        2.048e3
-        2.097e6
-        2.147e9
-             NA
+        NA     
     Code
       with_options(pillar.max_dec_width = 8, pillar::pillar_shaft(x))
     Output
@@ -83,5 +70,179 @@
       2.05e3
       2.10e6
       2.15e9
-          NA
+        NA  
+
+# decimal: omit decimal point when possible
+
+    Code
+      force_dec(bigfloat(10^(0:3)))
+    Output
+      <pillar_ornament>
+         1
+        10
+       100
+      1000
+
+# decimal: center aligned on decimal point
+
+    Code
+      force_dec(bigfloat((10^(-3:4)) * c(-1, 1)))
+    Output
+      <pillar_ornament>
+         -0.001
+          0.01 
+         -0.1  
+          1    
+        -10    
+        100    
+      -1000    
+      10000    
+
+# decimal: special values alignment
+
+    Code
+      force_dec(bigfloat(c(987.654, NA, NaN, Inf, 0.00123)))
+    Output
+      <pillar_ornament>
+      988.     
+       NA      
+      NaN      
+      Inf      
+        0.00123
+
+---
+
+    Code
+      force_dec(bigfloat(c(987.654, NA, NaN, Inf, -Inf, 0.00123)))
+    Output
+      <pillar_ornament>
+      988.     
+             NA
+            NaN
+            Inf
+           -Inf
+        0.00123
+
+# decimal: sigfig adjustment works
+
+    Code
+      x <- bigfloat(9.87654321) * 10^(3:-3)
+      force_dec(x)
+    Output
+      <pillar_ornament>
+      9877.     
+       988.     
+        98.8    
+         9.88   
+         0.988  
+         0.0988 
+         0.00988
+    Code
+      with_options(pillar.sigfig = 5, force_dec(x))
+    Output
+      <pillar_ornament>
+      9876.5      
+       987.65     
+        98.765    
+         9.8765   
+         0.98765  
+         0.098765 
+         0.0098765
+
+# scientific: omit signs when possible
+
+    Code
+      force_sci(bigfloat(10^(0:3)))
+    Output
+      <pillar_ornament>
+      1e0
+      1e1
+      1e2
+      1e3
+
+# scientific: include signs when necessary
+
+    Code
+      force_sci(bigfloat((10^(-3:4)) * c(-1, 1)))
+    Output
+      <pillar_ornament>
+      -1e-3
+       1e-2
+      -1e-1
+       1e+0
+      -1e+1
+       1e+2
+      -1e+3
+       1e+4
+
+# scientific: omit exponent when possible
+
+    Code
+      force_sci(bigfloat(c(0, 1, 10)))
+    Output
+      <pillar_ornament>
+      0  
+      1e0
+      1e1
+
+# scientific: exponent is right aligned
+
+    Code
+      force_sci(bigfloat(c(1e-100, 1, 1e+10)))
+    Output
+      <pillar_ornament>
+      1e-100
+      1e+  0
+      1e+ 10
+
+# scientific: special values alignment
+
+    Code
+      force_sci(bigfloat(c(987.654, NA, NaN, Inf, 0.00123)))
+    Output
+      <pillar_ornament>
+      9.88e+2
+        NA   
+       NaN   
+       Inf   
+      1.23e-3
+
+---
+
+    Code
+      force_sci(bigfloat(c(987.654, NA, NaN, Inf, -Inf, 0.00123)))
+    Output
+      <pillar_ornament>
+      9.88e+2
+        NA   
+       NaN   
+       Inf   
+      -Inf   
+      1.23e-3
+
+# scientific: sigfig adjustment works
+
+    Code
+      x <- bigfloat(9.87654321) * 10^(3:-3)
+      force_sci(x)
+    Output
+      <pillar_ornament>
+      9.88e+3
+      9.88e+2
+      9.88e+1
+      9.88e+0
+      9.88e-1
+      9.88e-2
+      9.88e-3
+    Code
+      with_options(pillar.sigfig = 5, force_sci(x))
+    Output
+      <pillar_ornament>
+      9.8765e+3
+      9.8765e+2
+      9.8765e+1
+      9.8765e+0
+      9.8765e-1
+      9.8765e-2
+      9.8765e-3
 

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -1,57 +1,48 @@
 test_that("bigfloat: input validation", {
-  expect_snapshot(
-    {
-      format(bigfloat(1), sigfig = 1, digits = 1)
+  expect_snapshot(error = TRUE, {
+    format(bigfloat(1), sigfig = 1, digits = 1)
 
-      format(bigfloat(1), sigfig = 1.5)
-      format(bigfloat(1), sigfig = "1")
-      format(bigfloat(1), sigfig = c(1, 2))
-      format(bigfloat(1), sigfig = 0)
+    format(bigfloat(1), sigfig = 1.5)
+    format(bigfloat(1), sigfig = "1")
+    format(bigfloat(1), sigfig = c(1, 2))
+    format(bigfloat(1), sigfig = 0)
 
-      format(bigfloat(1), digits = 1.5)
-      format(bigfloat(1), digits = "1")
-      format(bigfloat(1), digits = c(1, 2))
+    format(bigfloat(1), digits = 1.5)
+    format(bigfloat(1), digits = "1")
+    format(bigfloat(1), digits = c(1, 2))
 
-      format(bigfloat(1), notation = "hex")
-    },
-    error = TRUE
-  )
+    format(bigfloat(1), notation = "hex")
+  })
 })
 
 test_that("biginteger: input validation", {
-  expect_snapshot(
-    {
-      format(biginteger(1), notation = "sci", sigfig = 1, digits = 1)
+  expect_snapshot(error = TRUE, {
+    format(biginteger(1), notation = "sci", sigfig = 1, digits = 1)
 
-      format(biginteger(1), notation = "sci", sigfig = 1.5)
-      format(biginteger(1), notation = "sci", sigfig = "1")
-      format(biginteger(1), notation = "sci", sigfig = c(1, 2))
-      format(biginteger(1), notation = "sci", sigfig = 0)
+    format(biginteger(1), notation = "sci", sigfig = 1.5)
+    format(biginteger(1), notation = "sci", sigfig = "1")
+    format(biginteger(1), notation = "sci", sigfig = c(1, 2))
+    format(biginteger(1), notation = "sci", sigfig = 0)
 
-      format(biginteger(1), notation = "sci", digits = 1.5)
-      format(biginteger(1), notation = "sci", digits = "1")
-      format(biginteger(1), notation = "sci", digits = c(1, 2))
+    format(biginteger(1), notation = "sci", digits = 1.5)
+    format(biginteger(1), notation = "sci", digits = "1")
+    format(biginteger(1), notation = "sci", digits = c(1, 2))
 
-      format(biginteger(1), notation = "unknown")
-    },
-    error = TRUE
-  )
+    format(biginteger(1), notation = "unknown")
+  })
 })
 
 test_that("options: input validation", {
-  expect_snapshot(
-    {
-      with_options(bignum.sigfig = 1.5, format(bigfloat(1)))
-      with_options(bignum.sigfig = "1", format(bigfloat(1)))
-      with_options(bignum.sigfig = c(1, 2), format(bigfloat(1)))
-      with_options(bignum.sigfig = 0, format(bigfloat(1)))
+  expect_snapshot(error = TRUE, {
+    with_options(bignum.sigfig = 1.5, format(bigfloat(1)))
+    with_options(bignum.sigfig = "1", format(bigfloat(1)))
+    with_options(bignum.sigfig = c(1, 2), format(bigfloat(1)))
+    with_options(bignum.sigfig = 0, format(bigfloat(1)))
 
-      with_options(bignum.max_dec_width = 1.5, format(bigfloat(1)))
-      with_options(bignum.max_dec_width = "1", format(bigfloat(1)))
-      with_options(bignum.max_dec_width = c(1, 2), format(bigfloat(1)))
-    },
-    error = TRUE
-  )
+    with_options(bignum.max_dec_width = 1.5, format(bigfloat(1)))
+    with_options(bignum.max_dec_width = "1", format(bigfloat(1)))
+    with_options(bignum.max_dec_width = c(1, 2), format(bigfloat(1)))
+  })
 })
 
 test_that("bigfloat: dec notation works", {

--- a/tests/testthat/test-pillar.R
+++ b/tests/testthat/test-pillar.R
@@ -1,3 +1,21 @@
+force_dec <- function(x) {
+  out <- with_options(pillar.max_dec_width = Inf, pillar::pillar_shaft(x))
+  out$sci <- NULL
+  attr(out, "width") <- attr(out$dec, "width")
+  attr(out, "min_width") <- attr(out$dec, "width")
+  out
+}
+
+force_sci <- function(x) {
+  out <- pillar::pillar_shaft(x)
+  if (!is.null(out$dec)) {
+    out$dec <- NULL
+    attr(out, "width") <- attr(out$sci, "width")
+    attr(out, "min_width") <- attr(out$sci, "width")
+  }
+  out
+}
+
 test_that("options validation", {
   expect_snapshot(error = TRUE, {
     with_options(pillar.sigfig = 1.5, pillar::pillar_shaft(bigfloat(1)))
@@ -13,7 +31,7 @@ test_that("options validation", {
   })
 })
 
-test_that("biginteger formats correctly", {
+test_that("width calculations work", {
   expect_error(print(pillar::pillar_shaft(biginteger(2)^40L), width = 5))
 
   expect_snapshot({
@@ -21,17 +39,56 @@ test_that("biginteger formats correctly", {
     pillar::pillar_shaft(x)
     print(pillar::pillar_shaft(x), width = 8)
     print(pillar::pillar_shaft(x), width = 9)
+    with_options(pillar.max_dec_width = 8, pillar::pillar_shaft(x))
   })
+})
 
+test_that("decimal: omit decimal point when possible", {
+  expect_snapshot(force_dec(bigfloat(10^(0:3))))
+})
+
+test_that("decimal: center aligned on decimal point", {
+  expect_snapshot(force_dec(bigfloat((10^(-3:4)) * c(-1, 1))))
+})
+
+test_that("decimal: special values alignment", {
+  expect_snapshot(force_dec(bigfloat(c(987.654, NA, NaN, Inf, 0.00123))))
+  expect_snapshot(force_dec(bigfloat(c(987.654, NA, NaN, Inf, -Inf, 0.00123))))
+})
+
+test_that("decimal: sigfig adjustment works", {
   expect_snapshot({
-    x <- c(biginteger(2^seq(1, 40, 10)), NA)
-    with_options(
-      pillar.sigfig = 4,
-      print(pillar::pillar_shaft(x), width = 9)
-    )
-    with_options(
-      pillar.max_dec_width = 8,
-      pillar::pillar_shaft(x)
-    )
+    x <- bigfloat(9.87654321) * 10^(3:-3)
+    force_dec(x)
+    with_options(pillar.sigfig = 5, force_dec(x))
+  })
+})
+
+test_that("scientific: omit signs when possible", {
+  expect_snapshot(force_sci(bigfloat(10^(0:3))))
+})
+
+test_that("scientific: include signs when necessary", {
+  expect_snapshot(force_sci(bigfloat((10^(-3:4)) * c(-1, 1))))
+})
+
+test_that("scientific: omit exponent when possible", {
+  expect_snapshot(force_sci(bigfloat(c(0, 1, 10))))
+})
+
+test_that("scientific: exponent is right aligned", {
+  expect_snapshot(force_sci(bigfloat(c(1e-100, 1e0, 1e10))))
+})
+
+test_that("scientific: special values alignment", {
+  expect_snapshot(force_sci(bigfloat(c(987.654, NA, NaN, Inf, 0.00123))))
+  expect_snapshot(force_sci(bigfloat(c(987.654, NA, NaN, Inf, -Inf, 0.00123))))
+})
+
+test_that("scientific: sigfig adjustment works", {
+  expect_snapshot({
+    x <- bigfloat(9.87654321) * 10^(3:-3)
+    force_sci(x)
+    with_options(pillar.sigfig = 5, force_sci(x))
   })
 })

--- a/tests/testthat/test-pillar.R
+++ b/tests/testthat/test-pillar.R
@@ -1,22 +1,16 @@
 test_that("options validation", {
-  expect_snapshot(
-    {
-      with_options(pillar.sigfig = 1.5, pillar::pillar_shaft(bigfloat(1)))
-      with_options(pillar.sigfig = "1", pillar::pillar_shaft(bigfloat(1)))
-      with_options(pillar.sigfig = c(1, 2), pillar::pillar_shaft(bigfloat(1)))
-      with_options(pillar.sigfig = 0, pillar::pillar_shaft(bigfloat(1)))
-    },
-    error = TRUE
-  )
+  expect_snapshot(error = TRUE, {
+    with_options(pillar.sigfig = 1.5, pillar::pillar_shaft(bigfloat(1)))
+    with_options(pillar.sigfig = "1", pillar::pillar_shaft(bigfloat(1)))
+    with_options(pillar.sigfig = c(1, 2), pillar::pillar_shaft(bigfloat(1)))
+    with_options(pillar.sigfig = 0, pillar::pillar_shaft(bigfloat(1)))
+  })
 
-  expect_snapshot(
-    {
-      with_options(pillar.max_dec_width = 1.5, pillar::pillar_shaft(bigfloat(1)))
-      with_options(pillar.max_dec_width = "1", pillar::pillar_shaft(bigfloat(1)))
-      with_options(pillar.max_dec_width = c(1, 2), pillar::pillar_shaft(bigfloat(1)))
-    },
-    error = TRUE
-  )
+  expect_snapshot(error = TRUE, {
+    with_options(pillar.max_dec_width = 1.5, pillar::pillar_shaft(bigfloat(1)))
+    with_options(pillar.max_dec_width = "1", pillar::pillar_shaft(bigfloat(1)))
+    with_options(pillar.max_dec_width = c(1, 2), pillar::pillar_shaft(bigfloat(1)))
+  })
 })
 
 test_that("biginteger formats correctly", {


### PR DESCRIPTION
Fixes #19.

A follow-up to #17, this adjusts formatting of the bignum vectors when they are stored in a tibble. I've tried to remain roughly consistent with how atomic vectors are displayed by pillar.

<img width="813" alt="image" src="https://user-images.githubusercontent.com/1804856/121446505-828c6780-c948-11eb-9213-2a924ba46dc5.png">
