### PR TITLE
Fix storing bignum vectors in data.frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ BugReports: https://github.com/davidchall/bignum/issues
 Depends: 
     R (>= 3.3.0)
 Imports: 
-    ellipsis,
     rlang,
     vctrs (>= 0.3.0)
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bignum (development version)
 
+* `format()` no longer checks for misspelled arguments. This previously caused issues when storing a bignum vector inside a data.frame or data.table (#25).
+
 # bignum 0.2.0
 
 ## New features

--- a/R/format.R
+++ b/R/format.R
@@ -57,7 +57,6 @@ NULL
 #' @export
 format.bignum_biginteger <- function(x, ..., sigfig = NULL, digits = NULL,
                                      notation = c("fit", "dec", "sci", "hex")) {
-  ellipsis::check_dots_empty()
   notation <- arg_match(notation)
 
   switch(notation,
@@ -77,7 +76,6 @@ format.bignum_biginteger <- function(x, ..., sigfig = NULL, digits = NULL,
 #' @export
 format.bignum_bigfloat <- function(x, ..., sigfig = NULL, digits = NULL,
                                    notation = c("fit", "dec", "sci")) {
-  ellipsis::check_dots_empty()
   notation <- arg_match(notation)
 
   if (notation == "fit") {

--- a/tests/testthat/_snaps/format.md
+++ b/tests/testthat/_snaps/format.md
@@ -36,16 +36,6 @@
       format(bigfloat(1), notation = "hex")
     Error <rlang_error>
       `notation` must be one of "fit", "dec", or "sci".
-    Code
-      format(bigfloat(1), notatoin = "sci")
-    Error <rlib_error_dots_nonempty>
-      `...` is not empty.
-      
-      We detected these problematic arguments:
-      * `notatoin`
-      
-      These dots only exist to allow future extensions and should be empty.
-      Did you misspecify an argument?
 
 # biginteger: input validation
 
@@ -85,16 +75,6 @@
       format(biginteger(1), notation = "unknown")
     Error <rlang_error>
       `notation` must be one of "fit", "dec", "sci", or "hex".
-    Code
-      format(biginteger(1), notatoin = "sci")
-    Error <rlib_error_dots_nonempty>
-      `...` is not empty.
-      
-      We detected these problematic arguments:
-      * `notatoin`
-      
-      These dots only exist to allow future extensions and should be empty.
-      Did you misspecify an argument?
 
 # options: input validation
 

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -12,8 +12,6 @@ test_that("bigfloat: input validation", {
     format(bigfloat(1), digits = c(1, 2))
 
     format(bigfloat(1), notation = "hex")
-
-    format(bigfloat(1), notatoin = "sci")
   })
 })
 
@@ -31,8 +29,6 @@ test_that("biginteger: input validation", {
     format(biginteger(1), notation = "sci", digits = c(1, 2))
 
     format(biginteger(1), notation = "unknown")
-
-    format(biginteger(1), notatoin = "sci")
   })
 })
 


### PR DESCRIPTION
No longer check that format() dots arguments are empty.

Fixes #25 