### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -150,8 +150,8 @@ test_that("missing value works", {
 test_that("difficult cases work", {
   expect_equal(biginteger(c(1, 1e10)), biginteger(c("1", "10000000000")))
   expect_equal(biginteger(c(1, 1e23)), biginteger(c("1", "100000000000000000000000")))
-  expect_equal(
-    expect_warning(biginteger(c(1, 1e-10)), class = "bignum_warning_cast_lossy"),
-    biginteger(c("1", "0"))
+  expect_warning(
+    expect_equal(biginteger(c(1, 1e-10)), biginteger(c("1", "0"))),
+    class = "bignum_warning_cast_lossy"
   )
 })


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
