### PR TITLE
Prevent evaluation of symbolic arguments in `do.call()`

### DIFF
--- a/R/conditions.R
+++ b/R/conditions.R
@@ -15,7 +15,7 @@ warn_on_lossy_cast <- function(expr, x_ptype = NULL, to_ptype = NULL) {
 
       condition_data <- unclass(err)
       condition_data$class <- c("bignum_warning_cast_lossy", "vctrs_error_cast_lossy")
-      do.call(warn, condition_data)
+      do.call(warn, condition_data, quote = TRUE)
 
       invokeRestart("vctrs_restart_error_cast_lossy")
     },


### PR DESCRIPTION
rlang 1.0.0 includes a `call` field in conditions which gets incorrectly evaluated by `do.call()`.

I made a minimal change to fix this, but I think I'd solve this problem with composition instead of inheritance. I.e. create a classed warning that stores the upstream error as a condition field inside the warning and then have the header/body/footer methods forward to the error object.

We plan to release rlang within 2 to 4 weeks.