### PR TITLE
Remove leading zeros in R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bignum (development version)
 
+`biginteger()` now accepts string inputs with leading zeros (#37).
+
 # bignum 0.3.0
 
 * New `seq.bignum_vctr()` for generating sequences of `biginteger` or `bigfloat` (#30).

--- a/R/biginteger.R
+++ b/R/biginteger.R
@@ -191,5 +191,8 @@ as_biginteger.default <- function(x) {
 
 #' @export
 as_biginteger.character <- function(x) {
+  # remove leading zeros
+  x <- sub("^0+", "", x)
+
   new_biginteger(x)
 }

--- a/tests/testthat/test-bigfloat.R
+++ b/tests/testthat/test-bigfloat.R
@@ -189,3 +189,10 @@ test_that("infinity works", {
   expect_equal(bigfloat(1) / 0, bigfloat(Inf))
   expect_equal(bigfloat(-1) / 0, bigfloat(-Inf))
 })
+
+test_that("leading zeros allowed", {
+  expect_equal(
+    bigfloat(c("01", "07", "08", "010")),
+    bigfloat(c(1, 7, 8, 10))
+  )
+})

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -155,3 +155,10 @@ test_that("difficult cases work", {
     class = "bignum_warning_cast_lossy"
   )
 })
+
+test_that("leading zeros allowed", {
+  expect_equal(
+    biginteger(c("01", "07", "08", "010")),
+    biginteger(c(1, 7, 8, 10))
+  )
+})


### PR DESCRIPTION
Fixes #37 

The `boost::multiprecision:cpp_int` class was interpreting leading zeroes in an unexpected way. We now remove leading zeros in R.