### PR TITLE
Remove leading zeros in C++

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # bignum (development version)
 
-`biginteger()` now accepts string inputs with leading zeros (#37).
+* `biginteger()` now accepts strings with leading zeros (#37).
+* Empty strings are now correctly treated as missing data (NA).
+* Fix for CRAN checks.
 
 # bignum 0.3.0
 

--- a/R/biginteger.R
+++ b/R/biginteger.R
@@ -191,8 +191,5 @@ as_biginteger.default <- function(x) {
 
 #' @export
 as_biginteger.character <- function(x) {
-  # remove leading zeros
-  x <- sub("^0+", "", x)
-
   new_biginteger(x)
 }

--- a/src/bigfloat_vector.cpp
+++ b/src/bigfloat_vector.cpp
@@ -9,7 +9,7 @@ bigfloat_vector::bigfloat_vector(cpp11::strings x) : bigfloat_vector(x.size()) {
       cpp11::check_user_interrupt();
     }
 
-    if (x[i] == NA_STRING) {
+    if (x[i] == NA_STRING || x[i].size() == 0) {
       is_na[i] = true;
     } else {
       try {

--- a/src/biginteger_vector.cpp
+++ b/src/biginteger_vector.cpp
@@ -15,10 +15,12 @@ biginteger_vector::biginteger_vector(cpp11::strings x) : biginteger_vector(x.siz
       try {
         std::string str(x[i]);
 
-        // remove leading zeros
-        size_t n_lead_zero = str.find_first_not_of('0');
-        n_lead_zero = std::max((size_t)0, std::min(n_lead_zero, str.size()-1));
-        str.erase(0, n_lead_zero);
+        // remove leading zeros (unless hexadecimal)
+        if (str[0] == '0') {
+          if (str.size() >= 2 && str.compare(0, 2, "0x") != 0 && str.compare(0, 2, "0X") != 0) {
+            str.erase(0, str.find_first_not_of('0'));
+          }
+        }
 
         data[i] = biginteger_type(str);
       } catch (...) {

--- a/src/biginteger_vector.cpp
+++ b/src/biginteger_vector.cpp
@@ -9,11 +9,18 @@ biginteger_vector::biginteger_vector(cpp11::strings x) : biginteger_vector(x.siz
       cpp11::check_user_interrupt();
     }
 
-    if (x[i] == NA_STRING) {
+    if (x[i] == NA_STRING || x[i].size() == 0) {
       is_na[i] = true;
     } else {
       try {
-        data[i] = biginteger_type(std::string(x[i]));
+        std::string str(x[i]);
+
+        // remove leading zeros
+        size_t n_lead_zero = str.find_first_not_of('0');
+        n_lead_zero = std::max((size_t)0, std::min(n_lead_zero, str.size()-1));
+        str.erase(0, n_lead_zero);
+
+        data[i] = biginteger_type(str);
       } catch (...) {
         is_na[i] = true;
       }

--- a/tests/testthat/test-bigfloat.R
+++ b/tests/testthat/test-bigfloat.R
@@ -10,6 +10,7 @@ test_that("data input works", {
 })
 
 test_that("input validation works", {
+  expect_equal(bigfloat(""), NA_bigfloat_)
   expect_equal(bigfloat("hello"), NA_bigfloat_)
 })
 
@@ -192,7 +193,7 @@ test_that("infinity works", {
 
 test_that("leading zeros allowed", {
   expect_equal(
-    bigfloat(c("01", "07", "08", "010")),
-    bigfloat(c(1, 7, 8, 10))
+    bigfloat(c("00", "01", "07", "08", "010")),
+    bigfloat(c(0, 1, 7, 8, 10))
   )
 })

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -10,6 +10,7 @@ test_that("data input works", {
 })
 
 test_that("input validation works", {
+  expect_equal(biginteger(""), NA_biginteger_)
   expect_equal(biginteger("hello"), NA_biginteger_)
 })
 
@@ -158,7 +159,7 @@ test_that("difficult cases work", {
 
 test_that("leading zeros allowed", {
   expect_equal(
-    biginteger(c("01", "07", "08", "010")),
-    biginteger(c(1, 7, 8, 10))
+    biginteger(c("00", "01", "07", "08", "010")),
+    biginteger(c(0, 1, 7, 8, 10))
   )
 })

--- a/tests/testthat/test-biginteger.R
+++ b/tests/testthat/test-biginteger.R
@@ -7,6 +7,11 @@ test_that("zero-length input works", {
 test_that("data input works", {
   expect_length(biginteger(1L), 1)
   expect_length(biginteger(c(1L, 2)), 2)
+
+  expect_equal(biginteger(c(0L, 28L, -234L)), c(biginteger(0L), biginteger(28L), biginteger(-234L)))
+  expect_equal(biginteger(c(0, 28, -234)), biginteger(c(0L, 28L, -234L)))
+  expect_equal(biginteger(c("0", "28", "-234")), biginteger(c(0L, 28L, -234L)))
+  expect_equal(biginteger(c("0x0", "0xff", "0Xff")), biginteger(c(0, 255L, 255L)))
 })
 
 test_that("input validation works", {


### PR DESCRIPTION
New fix for #37 (supercedes #40), which restores hexadecimal support. We now also handle empty input strings.

| Input | bignum 0.3.0 | Previous fix | This fix |
|------|----------| --------|-------|
| "08" | NA | 8 | 8 |
| "00" | 0 | 0 | 0 |
| "" | 0 | 0 | NA |
| "0xff" | 255 | NA | 255 |
